### PR TITLE
Recreate dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot isn't picking up the dependabot.yml file, deleting and recreating the file might kick the system